### PR TITLE
Update scheduler start method

### DIFF
--- a/bot_logic.py
+++ b/bot_logic.py
@@ -1611,10 +1611,16 @@ class SubscriberTrackingBot:
         # הפעלת מתזמן ההתראות
         if self.scheduler:
             try:
-                self.scheduler.start()
-                logger.info("✅ Scheduler started")
+                import asyncio
+
+                async def start_scheduler_later():
+                    await asyncio.sleep(0.1)
+                    self.scheduler.start()
+
+                asyncio.create_task(start_scheduler_later())
+                logger.info("✅ Scheduler scheduled to start")
             except Exception as e:
-                logger.warning(f"⚠️ Scheduler couldn't start: {e}")
+                logger.warning(f"⚠️ Scheduler couldn't schedule: {e}")
         else:
             logger.warning("⚠️ Scheduler is None")
 

--- a/main.py
+++ b/main.py
@@ -34,16 +34,13 @@ def main():
         bot = SubscriberTrackingBot()
         logger.info("📡 Bot initialized")
 
-        # Start scheduler if defined
-        if getattr(bot, "scheduler", None):
-            try:
-                bot.scheduler.start()
-                logger.info("✅ Scheduler started")
-            except Exception as e:
-                logger.warning(f"⚠️ Scheduler couldn't start: {e}")
+        # Run bot inside asyncio event loop so that scheduler can start safely
+        import asyncio
 
-        logger.info("▶️ Running bot polling…")
-        bot.app.run_polling()
+        async def _run_bot():
+            await bot.run()
+
+        asyncio.run(_run_bot())
     except Exception as e:
         logger.error(f"❌ Unexpected error: {e}")
         raise


### PR DESCRIPTION
Start the scheduler asynchronously to prevent `no running event loop` errors.