### PR TITLE
Fix event loop issues in bot

### DIFF
--- a/bot_logic.py
+++ b/bot_logic.py
@@ -1598,15 +1598,11 @@ def get_telegram_app():
         logger.error(f"Failed to create Telegram app: {e}")
         raise
 
+# הפעלה ישירה (אופציונלי) – ללא שימוש ב-asyncio.run()
 if __name__ == "__main__":
-    import asyncio
-    try:
-        asyncio.run(main())
-    except RuntimeError as e:
-        if "asyncio.run()" in str(e) and "event loop is running" in str(e):
-            import nest_asyncio
-            nest_asyncio.apply()
-            loop = asyncio.get_event_loop()
-            loop.run_until_complete(main())
-        else:
-            raise
+    import nest_asyncio, asyncio
+    nest_asyncio.apply()
+    loop = asyncio.get_event_loop()
+    bot = SubscriberTrackingBot()
+    loop.create_task(bot.run())
+    loop.run_forever()

--- a/main.py
+++ b/main.py
@@ -20,6 +20,9 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+# Apply nest_asyncio immediately to patch running loops
+nest_asyncio.apply()
+
 # Dummy HTTP server עבור Render (כדי לשמור על פורט פתוח)
 class DummyHandler(BaseHTTPRequestHandler):
     def do_GET(self):
@@ -63,16 +66,9 @@ if __name__ == "__main__":
     # הפעלת השרת המדומה כ-thread נפרד
     threading.Thread(target=run_dummy_server, daemon=True).start()
 
-    # לולאת asyncio ל-Render – מטפלים במקרה שהלולאה כבר רצה
+    # יצירת לולאת asyncio ראשית (Render)
     loop = asyncio.get_event_loop()
 
-    if loop.is_running():
-        logger.warning("⚠️ Event loop already running. Applying nest_asyncio and scheduling start_bot() ...")
-        nest_asyncio.apply()
-        loop.create_task(start_bot())
-    else:
-        # אם הלולאה עדיין לא רצה, פשוט מריצים את הקורוטינה וכותבים run_forever לאחר מכן
-        loop.run_until_complete(start_bot())
-
-    # השאר את הלולאה חיה תמיד – חיוני ב-Render
+    # יצירת משימת הבוט והרצת הלולאה לנצח
+    loop.create_task(start_bot())
     loop.run_forever()


### PR DESCRIPTION
Refactor bot startup to resolve asyncio event loop conflicts on Render.

The previous setup could lead to `RuntimeError: This event loop is already running` when deploying on platforms like Render, which might have an active event loop. This PR introduces `nest_asyncio` and modifies the bot's startup sequence to correctly integrate with an existing loop, ensuring stable operation.