### PR TITLE
Debug Telegram bot message handling

### DIFF
--- a/bot_logic.py
+++ b/bot_logic.py
@@ -1571,12 +1571,27 @@ class SubscriberTrackingBot:
         # Ensure the /start health-check handler is registered exactly once
         self.app.add_handler(CommandHandler("start", self.start))
 
-        logger.info("▶️ Starting bot polling via run_polling() …")
+        logger.info("▶️ Starting bot polling (manual async) …")
 
         try:
-            # In PTB ≥ 21 `run_polling` can be awaited directly when
-            # close_loop=False, making the startup sequence MUCH simpler.
-            await self.app.run_polling(close_loop=False)
+            # For python-telegram-bot v20.x `run_polling` is a **blocking synchronous**
+            # helper that should *not* be awaited inside an async function. Attempting
+            # to do so will raise a `TypeError: object X is not awaitable` and the bot
+            # will silently exit after the initial "Application started" log ✓
+            #
+            # Therefore we start the application *manually* using the fully async
+            # lifecycle methods that ptb exposes: `initialize()`, `start()`, then
+            # `updater.start_polling()` followed by `updater.idle()`. This sequence
+            # keeps the current event-loop alive and makes sure the bot actually
+            # polls Telegram for updates.
+
+            await self.app.initialize()
+            await self.app.start()
+            # `start_polling()` launches the updater task that pulls updates in the
+            # background. It is a coroutine in PTB ≥ 20.x, so we await it here.
+            await self.app.updater.start_polling()
+            # Block until the application is shut down (ctrl-C / SIGTERM on Render)
+            await self.app.updater.idle()
         except Exception as e:
             logger.exception(f"❌ Unexpected error inside bot: {e}")
 


### PR DESCRIPTION
Update Telegram bot polling logic to be compatible with `python-telegram-bot` v20.

The bot was not responding to messages because `await self.app.run_polling()` was used, which is only awaitable in `python-telegram-bot` v21+. The `requirements.txt` specified v20, leading to a `TypeError` and the bot silently exiting after startup, failing to listen for updates.