### PR TITLE
Resolve package version conflicts

### DIFF
--- a/DEPENDENCY_CONFLICT_RESOLUTION.md
+++ b/DEPENDENCY_CONFLICT_RESOLUTION.md
@@ -1,0 +1,52 @@
+# Dependency Conflict Resolution
+
+## Issue Summary
+The project had a dependency conflict between `python-telegram-bot==13.15` and `APScheduler==3.10.4`:
+- `python-telegram-bot==13.15` requires `APScheduler==3.6.3`
+- The requirements.txt specified `APScheduler==3.10.4`
+- This created an incompatible dependency conflict preventing package installation
+
+## Root Cause Analysis
+The conflict occurred because:
+1. **Legacy Version**: `python-telegram-bot==13.15` is from 2021-2022 and has a hard dependency on `APScheduler==3.6.3`
+2. **Version Mismatch**: The requirements.txt had a much newer APScheduler version (3.10.4) that wasn't compatible
+3. **Dependency Evolution**: Modern `python-telegram-bot` versions (v20+) made APScheduler optional, but v13.15 requires it
+
+## Code Impact Analysis
+After reviewing the bot code (`bot_logic.py`), I found:
+- APScheduler is imported: `from apscheduler.schedulers.asyncio import AsyncIOScheduler`
+- Scheduler is initialized: `self.scheduler = AsyncIOScheduler()`
+- Scheduler is started: `self.scheduler.start()`
+- **No actual scheduled jobs are being added** - the scheduler infrastructure is set up but not actively used
+- CronTrigger is imported but never used
+
+## Resolution Applied
+**Updated requirements.txt**:
+- Changed `APScheduler==3.10.4` to `APScheduler==3.6.3`
+- This matches the exact version required by `python-telegram-bot==13.15`
+- No code changes were needed since the APScheduler usage is minimal
+
+## Why This Solution Works
+1. **Minimal Breaking Changes**: The bot code only uses basic APScheduler functionality
+2. **Backward Compatibility**: APScheduler 3.6.3 provides all the features currently used
+3. **Maintains Functionality**: The scheduler infrastructure remains intact for future use
+4. **Immediate Fix**: Resolves the dependency conflict without requiring code refactoring
+
+## Alternative Solutions Considered
+1. **Upgrade python-telegram-bot to v20+**: Would require significant code changes due to asyncio migration
+2. **Remove APScheduler**: Would require code cleanup and remove future scheduling capabilities
+3. **Use version ranges**: Less predictable and might cause issues in production
+
+## Verification
+The updated requirements.txt should now install successfully:
+```bash
+pip install -r requirements.txt
+```
+
+## Future Recommendations
+- Consider upgrading to `python-telegram-bot>=20.0` for better dependency management
+- Modern versions make APScheduler optional and use: `pip install "python-telegram-bot[job-queue]"`
+- This would provide more flexibility and newer features, but requires code migration to async patterns
+
+## Status
+✅ **RESOLVED**: Dependency conflict fixed with minimal impact to existing functionality.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 python-telegram-bot==13.15
 requests>=2.31.0
-APScheduler==3.10.4
+APScheduler==3.6.3
 python-dotenv>=1.0.0
 Pillow>=10.0.0
 pytesseract>=0.3.10


### PR DESCRIPTION
Downgrade APScheduler to version 3.6.3 to resolve a dependency conflict with python-telegram-bot.

The existing bot code uses APScheduler minimally, only initializing it without adding scheduled jobs. This allows downgrading to the older version required by `python-telegram-bot==13.15` without impacting current functionality or requiring code changes.