### PR TITLE
Fix missing imghdr module error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ python-dotenv>=1.0.0
 Pillow>=10.0.0
 pytesseract>=0.3.10
 nest_asyncio>=1.5.8
+standard-imghdr>=3.13.0


### PR DESCRIPTION
Add `standard-imghdr` to resolve `ModuleNotFoundError` for `imghdr` on Python 3.13.

The `imghdr` module was removed from the Python standard library in version 3.13. This change caused a `ModuleNotFoundError` for `python-telegram-bot` (and other libraries) which still depend on `imghdr`. Adding `standard-imghdr` provides a back-ported version of the module.