### PR TITLE
Fix missing imghdr module error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ python-dotenv>=1.0.0
 Pillow>=10.0.0
 pytesseract>=0.3.10
 nest_asyncio>=1.5.8
+standard-imghdr>=3.13.0


### PR DESCRIPTION
Add `standard-imghdr` to `requirements.txt` to resolve `imghdr` module not found error in Python 3.13.

The `imghdr` module was removed in Python 3.13, causing `ModuleNotFoundError` for libraries like `python-telegram-bot` that still depend on it. `standard-imghdr` reinstates this module, allowing the application to run correctly.